### PR TITLE
Feature/last user settings

### DIFF
--- a/Module.php
+++ b/Module.php
@@ -33,5 +33,7 @@ class Module extends AbstractModule
         $connection->exec("ALTER TABLE csvimport_import DROP FOREIGN KEY FK_17B508814C276F75;");
         $connection->exec("DROP TABLE csvimport_entity;");
         $connection->exec("DROP TABLE csvimport_import;");
+
+        // User settings are not removed here: they belong to the user.
     }
 }

--- a/config/module.config.php
+++ b/config/module.config.php
@@ -64,6 +64,12 @@ return [
         'oembed' => null,
         'youtube' => null,
     ],
+    'csv_import' => [
+        'user_settings' => [
+            'csv_import_multivalue_separator' => ',',
+            'csv_import_global_language' => '',
+        ],
+    ],
     'router' => [
         'routes' => [
             'admin' => [

--- a/src/Form/MappingForm.php
+++ b/src/Form/MappingForm.php
@@ -15,6 +15,9 @@ class MappingForm extends Form
         $resourceType = $this->getOption('resourceType');
         $serviceLocator = $this->getServiceLocator();
         $currentUser = $serviceLocator->get('Omeka\AuthenticationService')->getIdentity();
+        $userSettings = $serviceLocator->get('Omeka\Settings\User');
+        $config = $serviceLocator->get('Config');
+        $default = $config['csv_import']['user_settings'];
         $acl = $serviceLocator->get('Omeka\Acl');
 
         $this->add([
@@ -30,7 +33,7 @@ class MappingForm extends Form
             ],
         ]);
 
-        if ($resourceType == 'items' || $resourceType == 'item_sets') {
+        if (in_array($resourceType, ['items', 'item_sets'])) {
             $urlHelper = $serviceLocator->get('ViewHelperManager')->get('url');
             $this->add([
                 'name' => 'o:resource_template[o:id]',
@@ -106,7 +109,7 @@ class MappingForm extends Form
                     'attributes' => [
                         'id' => 'select-owner',
                         'value' => $currentUser->getId(),
-                        ],
+                    ],
                     'options' => [
                         'label' => 'Owner', // @translate
                         'resource_value_options' => [
@@ -115,36 +118,40 @@ class MappingForm extends Form
                             'option_text_callback' => function ($user) {
                                 return $user->name();
                             },
-                            ],
                         ],
+                    ],
                 ]);
             }
 
             $this->add([
-                'name' => 'multivalue-separator',
+                'name' => 'multivalue_separator',
                 'type' => 'text',
                 'options' => [
                     'label' => 'Multivalue separator', // @translate
                     'info' => 'The separator to use for columns with multiple values', // @translate
                 ],
                 'attributes' => [
-                    'id' => 'multivalue-separator',
+                    'id' => 'multivalue_separator',
                     'class' => 'input-body',
-                    'value' => ',',
+                    'value' => $userSettings->get(
+                        'csv_import_multivalue_separator',
+                        $default['csv_import_multivalue_separator']),
                 ],
             ]);
 
             $this->add([
-                'name' => 'global-language',
+                'name' => 'global_language',
                 'type' => 'text',
                 'options' => [
                     'label' => 'Language', // @translate
                     'info' => 'Language setting to apply to all imported literal data. Individual property mappings can override the setting here.', // @translate
                 ],
                 'attributes' => [
-                    'id' => 'global-language',
+                    'id' => 'global_language',
                     'class' => 'input-body value-language',
-                    'value' => '',
+                    'value' => $userSettings->get(
+                        'csv_import_global_language',
+                        $default['csv_import_global_language']),
                 ],
             ]);
 

--- a/src/Mapping/ItemMapping.php
+++ b/src/Mapping/ItemMapping.php
@@ -43,7 +43,7 @@ class ItemMapping extends AbstractMapping
             $ownerId = $this->args['o:owner'];
             $itemJson['o:owner'] = ['o:id' => $ownerId];
         }
-        $multivalueSeparator = $this->args['multivalue-separator'];
+        $multivalueSeparator = $this->args['multivalue_separator'];
         $multivalueMap = isset($this->args['column-multivalue']) ? array_keys($this->args['column-multivalue']) : [];
         $itemSetMap = isset($this->args['column-itemset-id']) ? array_keys($this->args['column-itemset-id']) : [];
         $resourceTemplateMap = isset($this->args['column-resourcetemplate']) ? array_keys($this->args['column-resourcetemplate']) : [];

--- a/src/Mapping/MediaMapping.php
+++ b/src/Mapping/MediaMapping.php
@@ -27,7 +27,7 @@ class MediaMapping extends AbstractMapping
         $mediaJson = ['o:media' => []];
         $mediaMap = isset($this->args['media']) ? $this->args['media'] : [];
         $multivalueMap = isset($this->args['column-multivalue']) ? array_keys($this->args['column-multivalue']) : [];
-        $multivalueSeparator = $this->args['multivalue-separator'];
+        $multivalueSeparator = $this->args['multivalue_separator'];
         foreach ($row as $index => $values) {
             //split $values into an array, so people can have more than one file
             //in the column

--- a/src/Mapping/PropertyMapping.php
+++ b/src/Mapping/PropertyMapping.php
@@ -27,8 +27,8 @@ class PropertyMapping extends AbstractMapping
         $referenceMap = isset($this->args['column-reference']) ? array_keys($this->args['column-reference']) : [];
         $multivalueMap = isset($this->args['column-multivalue']) ? array_keys($this->args['column-multivalue']) : [];
         $languageSettings = isset($this->args['column-language']) ? $this->args['column-language'] : [];
-        $globalLanguage = isset($this->args['global-language']) ? $this->args['global-language'] : '';
-        $multivalueSeparator = $this->args['multivalue-separator'];
+        $globalLanguage = isset($this->args['global_language']) ? $this->args['global_language'] : '';
+        $multivalueSeparator = $this->args['multivalue_separator'];
         foreach ($row as $index => $values) {
             // consider 'literal' as the default type
             $type = 'literal';

--- a/src/Mapping/PropertyMapping.php
+++ b/src/Mapping/PropertyMapping.php
@@ -101,7 +101,6 @@ class PropertyMapping extends AbstractMapping
                                     'property_id' => $propertyId,
                                     'type' => $type,
                                 ];
-                                $this->logger->debug($globalLanguage);
                                 if ($globalLanguage !== '') {
                                     $literalPropertyJson['@language'] = $globalLanguage;
                                 }

--- a/src/Service/Controller/IndexControllerFactory.php
+++ b/src/Service/Controller/IndexControllerFactory.php
@@ -11,7 +11,8 @@ class IndexControllerFactory implements FactoryInterface
     {
         $mediaIngesterManager = $serviceLocator->get('Omeka\Media\Ingester\Manager');
         $config = $serviceLocator->get('Config');
-        $indexController = new IndexController($config, $mediaIngesterManager);
+        $userSettings = $serviceLocator->get('Omeka\Settings\User');
+        $indexController = new IndexController($config, $mediaIngesterManager, $userSettings);
         return $indexController;
     }
 }


### PR DESCRIPTION
The last params are saved as last settings.

The default settings are set in the module config in the subarray `csv_import['user_settings']`, and I like to set other settings (`csv_import_mappings` and `csv_import_media_ingester_adapter`) inside this array too for better management, but it implies a change of the param in the module Mapping and FileSideload, so it will be in a next pull request if ok. Nevertheless, the user settings can be saved as value of an inexisting core `user_settings` too, or in a subarray `csv_import` of it, so this is something to define.

See https://github.com/omeka/omeka-s/issues/973#issuecomment-327781804