### PR TITLE
Added a way to import uri with a label, separated by a simple space.

### DIFF
--- a/src/Mapping/PropertyMapping.php
+++ b/src/Mapping/PropertyMapping.php
@@ -62,7 +62,7 @@ class PropertyMapping extends AbstractMapping
 
                 foreach ($propertyMap[$index] as $propertyTerm => $propertyId) {
                     if (empty($multivalueMap[$index])) {
-                        $values = [$values];
+                        $values = [trim($values)];
                     } else {
 
                         $values = explode($multivalueSeparator, $values);
@@ -72,10 +72,20 @@ class PropertyMapping extends AbstractMapping
                     foreach ($values as $value) {
                         switch ($type) {
                             case 'uri':
+                                // Check if a label is provided after the url.
+                                // Note: A url has no space, but a uri may have.
+                                if (strpos($value, ' ')) {
+                                    list($valueId, $valueLabel) = explode(' ', $value, 2);
+                                    $valueLabel = trim($valueLabel);
+                                } else {
+                                    $valueId = $value;
+                                    $valueLabel = null;
+                                }
                                 $data[$propertyTerm][] = [
-                                    '@id' => $value,
+                                    '@id' => $valueId,
                                     'property_id' => $propertyId,
                                     'type' => $type,
+                                    'o:label' => $valueLabel,
                                 ];
                                 break;
 


### PR DESCRIPTION
This fixes #157 when the uri and the label are in the same column, but not when they are in two columns (in that case, it may be difficult to manage when there are multiple uris, and some of them haven't a label). Test with [test_uri_label.ods](https://github.com/Daniel-KM/Omeka-S-module-BulkImport/raw/master/test/BulkImportTest/_files/test_uri_label.ods).