### PR TITLE
Add service to get the csv_import config directly

### DIFF
--- a/config/module.config.php
+++ b/config/module.config.php
@@ -49,6 +49,11 @@ return [
             'csvimport_imports' => Api\Adapter\ImportAdapter::class,
         ],
     ],
+    'service_manager' => [
+        'factories' => [
+            'CSVImport\Config' => Service\ConfigFactory::class,
+        ],
+    ],
     'router' => [
         'routes' => [
             'admin' => [

--- a/src/Controller/IndexController.php
+++ b/src/Controller/IndexController.php
@@ -36,15 +36,21 @@ class IndexController extends AbstractActionController
     protected $userSettings;
 
     /**
+     * @var string
+     */
+    protected $tempDir;
+
+    /**
      * @param array $config
      * @param Manager $mediaIngesterManager
      * @param UserSettings $userSettings
      */
-    public function __construct(array $config, Manager $mediaIngesterManager, UserSettings $userSettings)
+    public function __construct(array $config, Manager $mediaIngesterManager, UserSettings $userSettings, $tempDir)
     {
         $this->config = $config;
         $this->mediaIngesterManager = $mediaIngesterManager;
         $this->userSettings = $userSettings;
+        $this->tempDir = $tempDir;
     }
 
     public function indexAction()
@@ -229,7 +235,7 @@ class IndexController extends AbstractActionController
             }
         }
 
-        $sources = $this->config['csv_import']['sources'];
+        $sources = $this->config['sources'];
         if (!isset($sources[$mediaType])) {
             return;
         }
@@ -252,7 +258,7 @@ class IndexController extends AbstractActionController
         // before Laminas merge.
         $config = include dirname(dirname(__DIR__)) . '/config/module.config.php';
         $defaultOrder = $config['csv_import']['mappings'];
-        $mappings = $this->config['csv_import']['mappings'];
+        $mappings = $this->config['mappings'];
         if (isset($defaultOrder[$resourceType])) {
             $mappingClasses = array_values(array_unique(array_merge(
                 $defaultOrder[$resourceType], $mappings[$resourceType]
@@ -387,7 +393,7 @@ class IndexController extends AbstractActionController
     protected function getDataTypes()
     {
         $dataTypes = [];
-        $configDataTypes = $this->config['csv_import']['data_types'];
+        $configDataTypes = $this->config['data_types'];
         foreach ($configDataTypes as $id => $configEntry) {
             $dataTypes[$id] = $configEntry['label'];
         }
@@ -416,13 +422,11 @@ class IndexController extends AbstractActionController
             return $this->tempPath;
         }
         if (!isset($tempDir)) {
-            $config = $this->config;
-            if (!isset($config['temp_dir'])) {
+            if (!isset($this->tempDir)) {
                 throw new ConfigException('Missing temporary directory configuration');
             }
-            $tempDir = $config['temp_dir'];
         }
-        $this->tempPath = tempnam($tempDir, 'omeka');
+        $this->tempPath = tempnam($this->tempDir, 'omeka');
         return $this->tempPath;
     }
 
@@ -448,7 +452,7 @@ class IndexController extends AbstractActionController
      */
     protected function saveUserSettings(array $settings)
     {
-        foreach ($this->config['csv_import']['user_settings'] as $key => $value) {
+        foreach ($this->config['user_settings'] as $key => $value) {
             $name = substr($key, strlen('csv_import_'));
             if (isset($settings[$name])) {
                 $this->userSettings()->set($key, $settings[$name]);

--- a/src/Controller/IndexController.php
+++ b/src/Controller/IndexController.php
@@ -425,8 +425,9 @@ class IndexController extends AbstractActionController
             if (!isset($this->tempDir)) {
                 throw new ConfigException('Missing temporary directory configuration');
             }
+            $tempDir = $this->tempDir;
         }
-        $this->tempPath = tempnam($this->tempDir, 'omeka');
+        $this->tempPath = tempnam($tempDir, 'omeka');
         return $this->tempPath;
     }
 

--- a/src/Form/MappingForm.php
+++ b/src/Form/MappingForm.php
@@ -18,8 +18,8 @@ class MappingForm extends Form
         $resourceType = $this->getOption('resource_type');
         $serviceLocator = $this->getServiceLocator();
         $userSettings = $serviceLocator->get('Omeka\Settings\User');
-        $config = $serviceLocator->get('Config');
-        $default = $config['csv_import']['user_settings'];
+        $config = $serviceLocator->get('CSVImport\Config');
+        $default = $config['user_settings'];
         $acl = $serviceLocator->get('Omeka\Acl');
 
         $this->add([

--- a/src/Job/Import.php
+++ b/src/Job/Import.php
@@ -105,7 +105,7 @@ class Import extends AbstractJob
         $this->logger = $services->get('Omeka\Logger');
         $this->findResourcesFromIdentifiers = $services->get('ControllerPluginManager')
             ->get('findResourcesFromIdentifiers');
-        $config = $services->get('Config');
+        $config = $services->get('CSVImport\Config');
 
         $this->args = $this->job->getArgs();
         $args = &$this->args;
@@ -116,7 +116,7 @@ class Import extends AbstractJob
         $this->importResource = $this->resourceType === 'resources';
 
         $this->mappings = [];
-        $mappingClasses = $config['csv_import']['mappings'][$this->resourceType];
+        $mappingClasses = $config['mappings'][$this->resourceType];
         foreach ($mappingClasses as $mappingClass) {
             $mapping = new $mappingClass();
             $mapping->init($args, $services);
@@ -1049,7 +1049,7 @@ SQL;
             }
         }
 
-        $sources = $this->getServiceLocator()->get('Config')['csv_import']['sources'];
+        $sources = $this->getServiceLocator()->get('CSVImport\Config')['sources'];
         if (!isset($sources[$mediaType])) {
             return;
         }

--- a/src/Mapping/MediaSourceMapping.php
+++ b/src/Mapping/MediaSourceMapping.php
@@ -50,8 +50,8 @@ class MediaSourceMapping extends AbstractMapping
             return $data;
         }
 
-        $config = $this->getServiceLocator()->get('Config');
-        $mediaAdapters = $config['csv_import']['media_ingester_adapter'];
+        $config = $this->getServiceLocator()->get('CSVImport\Config');
+        $mediaAdapters = $config['media_ingester_adapter'];
         $action = $this->args['action'];
 
         $multivalueMap = isset($this->args['column-multivalue']) ? $this->args['column-multivalue'] : [];

--- a/src/Mapping/PropertyMapping.php
+++ b/src/Mapping/PropertyMapping.php
@@ -142,8 +142,8 @@ class PropertyMapping extends AbstractMapping
     {
         $dataTypeAdapters = [];
 
-        $config = $this->getServiceLocator()->get('Config');
-        $dataTypeConfig = $config['csv_import']['data_types'];
+        $config = $this->getServiceLocator()->get('CSVImport\Config');
+        $dataTypeConfig = $config['data_types'];
         foreach ($dataTypeConfig as $id => $configEntry) {
             $dataTypeAdapters[$id] = $configEntry['adapter'];
         }

--- a/src/Service/ConfigFactory.php
+++ b/src/Service/ConfigFactory.php
@@ -1,0 +1,19 @@
+<?php
+namespace CSVImport\Service;
+
+use Laminas\EventManager\Event;
+use Laminas\ServiceManager\Factory\FactoryInterface;
+use Interop\Container\ContainerInterface;
+
+class ConfigFactory implements FactoryInterface
+{
+    public function __invoke(ContainerInterface $services, $requestedName, array $options = null)
+    {
+        $config = $services->get('Config')['csv_import'];
+        $eventManager = $services->get('EventManager');
+
+        $args = $eventManager->prepareArgs(['config' => $config]);
+        $eventManager->triggerEvent(new Event('csv_import.config', null, $args));
+        return $args['config'];
+    }
+}

--- a/src/Service/Controller/IndexControllerFactory.php
+++ b/src/Service/Controller/IndexControllerFactory.php
@@ -10,10 +10,11 @@ class IndexControllerFactory implements FactoryInterface
     public function __invoke(ContainerInterface $serviceLocator, $requestedName, array $options = null)
     {
         $mediaIngesterManager = $serviceLocator->get('Omeka\Media\Ingester\Manager');
-        $config = $serviceLocator->get('Config');
+        $config = $serviceLocator->get('CSVImport\Config');
         $userSettings = $serviceLocator->get('Omeka\Settings\User');
+        $tempDir = $serviceLocator->get('Config')['temp_dir'];
 
-        $indexController = new IndexController($config, $mediaIngesterManager, $userSettings);
+        $indexController = new IndexController($config, $mediaIngesterManager, $userSettings, $tempDir);
         return $indexController;
     }
 }

--- a/src/Service/ControllerPlugin/AutomapHeadersToMetadataFactory.php
+++ b/src/Service/ControllerPlugin/AutomapHeadersToMetadataFactory.php
@@ -9,9 +9,8 @@ class AutomapHeadersToMetadataFactory implements FactoryInterface
 {
     public function __invoke(ContainerInterface $serviceLocator, $requestedName, array $options = null)
     {
-        $config = $serviceLocator->get('Config');
         $plugin = new AutomapHeadersToMetadata();
-        $plugin->setConfigCsvImport($config['csv_import']);
+        $plugin->setConfigCsvImport($serviceLocator->get('CSVImport\Config'));
         return $plugin;
     }
 }

--- a/src/Service/Form/ImportFormFactory.php
+++ b/src/Service/Form/ImportFormFactory.php
@@ -10,8 +10,7 @@ class ImportFormFactory implements FactoryInterface
     public function __invoke(ContainerInterface $services, $requestedName, array $options = null)
     {
         $form = new ImportForm(null, $options);
-        $config = $services->get('Config');
-        $form->setConfigCsvImport($config['csv_import']);
+        $form->setConfigCsvImport($services->get('CSVImport\Config'));
         $form->setUserSettings($services->get('Omeka\Settings\User'));
         return $form;
     }

--- a/src/Service/ViewHelper/MediaSourceSidebarFactory.php
+++ b/src/Service/ViewHelper/MediaSourceSidebarFactory.php
@@ -9,10 +9,10 @@ class MediaSourceSidebarFactory implements FactoryInterface
 {
     public function __invoke(ContainerInterface $services, $requestedName, array $options = null)
     {
-        $config = $services->get('Config');
+        $config = $services->get('CSVImport\Config');
         $translator = $services->get('MvcTranslator');
         $ingesterManager = $services->get('Omeka\Media\Ingester\Manager');
-        $mediaAdapters = $config['csv_import']['media_ingester_adapter'];
+        $mediaAdapters = $config['media_ingester_adapter'];
         return new MediaSourceSidebar($ingesterManager, $mediaAdapters, $translator);
     }
 }


### PR DESCRIPTION
Modules normally extend functionality by modifying the `['csv_import']` configuration array in their own configuration file. This approach does not work for modules that need to add things dynamically, like when service names have to be built at runtime (e.g. when using `abstract_factories` to create services).

To allow for dynamic additions, this PR adds the `CSVImport/Config` service that returns the `['csv_import']` configuration array only. It passes the array through a new `csv_import.config` event, where other modules may modify it. All areas in the code that originally called the `Config` service now call the `CSVImport/Config` service.